### PR TITLE
Fixed a runtime error

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/scala/scala3/deployment/Scala3CompilationProvider.java
+++ b/deployment/src/main/java/io/quarkiverse/scala/scala3/deployment/Scala3CompilationProvider.java
@@ -115,7 +115,7 @@ public class Scala3CompilationProvider implements CompilationProvider {
     }
 
     @Override
-    public Path getSourcePath(Path classFilePath, PathsCollection sourcePaths, String classesPath) {
+    public Path getSourcePath(Path classFilePath, PathCollection sourcePaths, String classesPath) {
         return classFilePath;
     }
 


### PR DESCRIPTION
Exception in thread "main" java.lang.RuntimeException: java.lang.AbstractMethodError: Receiver class io.quarkiverse.scala.scala3.deployment.Scala3CompilationProvider does not define or inherit an implementation of the resolved method 'abstract java.nio.file.Path getSourcePath(java.nio.file.Path, io.quarkus.paths.PathCollection, java.lang.String)' of interface io.quarkus.deployment.dev.CompilationProvider.
        at io.quarkus.deployment.dev.DevModeMain.start(DevModeMain.java:138)
        at io.quarkus.deployment.dev.DevModeMain.main(DevModeMain.java:62)
Caused by: java.lang.AbstractMethodError: Receiver class io.quarkiverse.scala.scala3.deployment.Scala3CompilationProvider does not define or inherit an implementation of the resolved method 'abstract java.nio.file.Path getSourcePath(java.nio.file.Path, io.quarkus.paths.PathCollection, java.lang.String)' of interface io.quarkus.deployment.dev.CompilationProvider.
        at io.quarkus.deployment.dev.QuarkusCompiler.findSourcePath(QuarkusCompiler.java:201)