### PR TITLE
Read Scala options from pom.xml

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.scala</groupId>
@@ -37,6 +38,12 @@
       <groupId>org.scala-lang</groupId>
       <artifactId>scala3-interfaces</artifactId>
       <version>3.3.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>3.9.6</version>
     </dependency>
   </dependencies>
   <build>

--- a/deployment/src/main/java/io/quarkiverse/scala/scala3/deployment/Scala3CompilationProvider.java
+++ b/deployment/src/main/java/io/quarkiverse/scala/scala3/deployment/Scala3CompilationProvider.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.scala.scala3.deployment;
 
 import java.io.File;
+import java.io.FileReader;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -11,6 +12,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.jboss.logging.Logger;
 
 import dotty.tools.dotc.interfaces.AbstractFile;
@@ -58,12 +63,56 @@ import io.quarkus.paths.PathCollection;
  */
 public class Scala3CompilationProvider implements CompilationProvider {
 
-    private final Logger log = Logger.getLogger(Scala3CompilationProvider.class);
+    private final static Logger log = Logger.getLogger(Scala3CompilationProvider.class);
 
-    // There's currently no way for this kind of extension to use Config providers
-    // So the best way I can come up with passing compiler args is by accepting an ENV var
-    private static final String COMPILER_ARGS_ENV_VAR = "QUARKUS_SCALA3_COMPILER_ARGS";
-    private static final Optional<List<String>> COMPILER_ARGS = getCompilerArgsFromEnv();
+    static String COMPILER_ARGS_ENV_VAR = "QUARKUS_SCALA3_COMPILER_ARGS";
+    // Parse the xml file to get the Scala compiler args
+    private static final Optional<List<String>> COMPILER_ARGS = getCompilerArgs();
+
+    private static Optional<List<String>> getCompilerArgs() {
+        String projectRoot = System.getProperty("user.dir");
+        log.info("User dir: " + projectRoot);
+
+        // If the environment variable is set, use that
+        if (System.getenv(COMPILER_ARGS_ENV_VAR) != null) {
+            log.info("Compiler args from env: " + System.getenv(COMPILER_ARGS_ENV_VAR));
+            return getCompilerArgsFromEnv();
+        }
+
+        // Check if pom.xml exists
+        File pom = new File(projectRoot, "/pom.xml");
+        if (!pom.exists()) {
+            log.info("No pom.xml found, using compiler args from env");
+            return getCompilerArgsFromEnv();
+        } else {
+            // Scala args is in pom.xml under project -> build -> plugins ->
+            // plugin(scala-maven-plugin) -> configuration -> args
+            MavenXpp3Reader reader = new MavenXpp3Reader();
+            try {
+                Model model = reader.read(new FileReader(pom));
+                List<String> compilerArgs = new ArrayList<>();
+                Plugin plugin = model.getBuild().getPlugins().stream()
+                        .filter(p -> p.getArtifactId().equals("scala-maven-plugin")).findFirst().get();
+
+                Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+                for (Xpp3Dom arg : configuration.getChild("args").getChildren()) {
+                    if (arg.getValue() == null) {
+                        continue;
+                    }
+                    compilerArgs.add(arg.getValue());
+                }
+
+                log.info("Compiler args from pom.xml: " + compilerArgs);
+                return Optional.of(compilerArgs);
+
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                log.error(e.getStackTrace());
+
+                return Optional.empty();
+            }
+        }
+    }
 
     private static Optional<List<String>> getCompilerArgsFromEnv() {
         String compilerArgsString = System.getenv(COMPILER_ARGS_ENV_VAR);
@@ -141,18 +190,19 @@ public class Scala3CompilationProvider implements CompilationProvider {
         }
     }
 
-    // This is a no-op implementation right now, the super() calls invoke void methods
+    // This is a no-op implementation right now, the super() calls invoke void
+    // methods
     // But it's useful for future reference I think
     class CustomCompilerCallback implements CompilerCallback {
 
         /**
          * Called when a class has been generated.
          *
-         * @param source The source file corresponding to this class. Example:
-         *        ./src/library/scala/collection/Seq.scala
+         * @param source         The source file corresponding to this class. Example:
+         *                       ./src/library/scala/collection/Seq.scala
          * @param generatedClass The generated classfile for this class. Example:
-         *        ./scala/collection/Seq$.class
-         * @param className The name of this class.
+         *                       ./scala/collection/Seq$.class
+         * @param className      The name of this class.
          */
         @Override
         public void onClassGenerated(SourceFile source, AbstractFile generatedClass, String className) {
@@ -163,7 +213,7 @@ public class Scala3CompilationProvider implements CompilationProvider {
          * Called when every class for this file has been generated.
          *
          * @param source The source file. Example:
-         *        ./src/library/scala/collection/Seq.scala
+         *               ./src/library/scala/collection/Seq.scala
          */
         @Override
         public void onSourceCompiled(SourceFile source) {

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse</groupId>


### PR DESCRIPTION
This PR adds POM parsing to fetch Scala compiler options defined in the `scala-maven-plugin` configuration.

The environment variable still have preference if passed.