### PR TITLE
Bump Quarkus version to use latest Jackson lib. Update Readme.

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.scala</groupId>
@@ -36,7 +37,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala3-interfaces</artifactId>
-      <version>3.3.1</version>
+      <version>3.3.3</version>
     </dependency>
   </dependencies>
   <build>

--- a/deployment/src/main/java/io/quarkiverse/scala/scala3/deployment/Scala3Processor.java
+++ b/deployment/src/main/java/io/quarkiverse/scala/scala3/deployment/Scala3Processor.java
@@ -9,7 +9,6 @@ class Scala3Processor {
 
     private static final String FEATURE = "scala3";
     private static final String SCALA_JACKSON_MODULE = "com.fasterxml.jackson.module.scala.DefaultScalaModule";
-    private static final String SCALA_JACKSON_ENUM_MODULE = "com.github.pjfanning.enum.EnumModule";
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -17,8 +16,7 @@ class Scala3Processor {
     }
 
     /*
-     * Register the Scala Jackson module and Scala Enum module if that has been
-     * added to the classpath
+     * Register the Scala Jackson module if that has been added to the classpath
      * Producing the BuildItem is entirely safe since if quarkus-jackson is not on
      * the classpath the BuildItem will just be ignored
      */
@@ -27,8 +25,6 @@ class Scala3Processor {
         try {
             Class.forName(SCALA_JACKSON_MODULE, false, Thread.currentThread().getContextClassLoader());
             classPathJacksonModules.produce(new ClassPathJacksonModuleBuildItem(SCALA_JACKSON_MODULE));
-            Class.forName(SCALA_JACKSON_ENUM_MODULE, false, Thread.currentThread().getContextClassLoader());
-            classPathJacksonModules.produce(new ClassPathJacksonModuleBuildItem(SCALA_JACKSON_ENUM_MODULE));
         } catch (Exception ignored) {
         }
     }

--- a/deployment/src/main/java/io/quarkiverse/scala/scala3/deployment/Scala3Processor.java
+++ b/deployment/src/main/java/io/quarkiverse/scala/scala3/deployment/Scala3Processor.java
@@ -9,6 +9,7 @@ class Scala3Processor {
 
     private static final String FEATURE = "scala3";
     private static final String SCALA_JACKSON_MODULE = "com.fasterxml.jackson.module.scala.DefaultScalaModule";
+    private static final String SCALA_JACKSON_ENUM_MODULE = "com.github.pjfanning.enum.EnumModule";
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -16,7 +17,8 @@ class Scala3Processor {
     }
 
     /*
-     * Register the Scala Jackson module if that has been added to the classpath
+     * Register the Scala Jackson module and Scala Enum module if that has been
+     * added to the classpath
      * Producing the BuildItem is entirely safe since if quarkus-jackson is not on
      * the classpath the BuildItem will just be ignored
      */
@@ -25,6 +27,8 @@ class Scala3Processor {
         try {
             Class.forName(SCALA_JACKSON_MODULE, false, Thread.currentThread().getContextClassLoader());
             classPathJacksonModules.produce(new ClassPathJacksonModuleBuildItem(SCALA_JACKSON_MODULE));
+            Class.forName(SCALA_JACKSON_ENUM_MODULE, false, Thread.currentThread().getContextClassLoader());
+            classPathJacksonModules.produce(new ClassPathJacksonModuleBuildItem(SCALA_JACKSON_ENUM_MODULE));
         } catch (Exception ignored) {
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse</groupId>
@@ -24,7 +25,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.6.4</quarkus.version>
+    <quarkus.version>3.10.0</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This PR registers the Scala EnumModule automatically (if exists) to the default ObjectMapper.

Reflect this simplification to the Readme.