### PR TITLE
Future[T] and Promise[T] as Controller ReturnTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     - [Configuring Scala Jackson and the addon-on "Enum" module for JSON support](#configuring-scala-jackson-and-the-addon-on-enum-module-for-json-support)
     - [Scala DSL for rest-assured (similar to Kotlin DSL)](#scala-dsl-for-rest-assured-similar-to-kotlin-dsl)
     - [Functional HTTP routes (Vert.x handlers)](#functional-http-routes-vertx-handlers)
+- [Quarkus - Scala3 - Futures](#quarkus---scala3---futures)
 
 ## Introduction 
 
@@ -61,7 +62,6 @@ VERSIONS = [
 
 dependencies {
     implementation "io.quarkiverse.scala:quarkus-scala3:${VERSIONS.QUARKUS_SCALA3}"
-    implementation "io.quarkiverse.scala:quarkus-scala3-deployment:${VERSIONS.QUARKUS_SCALA3}"
     implementation("org.scala-lang:scala3-compiler_3") {
         version {
             strictly VERSIONS.SCALA3
@@ -135,11 +135,6 @@ In your `pom.xml` file, add:
     <groupId>io.quarkiverse.scala</groupId>
     <artifactId>quarkus-scala3</artifactId>
     <version>1.0.0<version>
-</dependency>
-<dependency>
-  <groupId>io.quarkiverse.scala</groupId>
-  <artifactId>quarkus-scala3-deployment</artifactId>
-  <version>1.0.0</version>
 </dependency>
 ```
 
@@ -446,10 +441,11 @@ def mkRoutes(router: Router) =
     })
 ```
 
+# Quarkus - Scala3 - Futures
 
-### `Future[T]` and `Promise[T]` support in REST endpoints
+# `Future[T]` and `Promise[T]` support in REST endpoints
 
-This extension allows you to return `Future[T]` and `Promise[T]` from your REST endpoints.
+The `quarkus-scala3-futures` extension allows you to return `Future[T]` and `Promise[T]` from your REST endpoints.
 
 ```scala
 
@@ -474,7 +470,7 @@ end GreetingResource
 
 If the `Future[T]` or `Promise[T]` fails, the normal exception handling is invoked.
 
-Make sure to have the following dependencies in your `pom.xml` to make it work:
+Make sure to have the following dependency in your `pom.xml` to make it work:
 
 ```xml
     <dependency>
@@ -483,12 +479,7 @@ Make sure to have the following dependencies in your `pom.xml` to make it work:
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.scala</groupId>
-      <artifactId>quarkus-scala3</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkiverse.scala</groupId>
-      <artifactId>quarkus-scala3-deployment</artifactId>
+      <artifactId>quarkus-scala3-futures</artifactId>
       <version>${project.version}</version>
     </dependency>
 ```
@@ -519,5 +510,5 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
 ## TODOs
- - correctly generate OpenAPI Spec for methods returning `Future[T]` or `Promise[T]`, e.g. similar to [Quarkus #8499](https://github.com/quarkusio/quarkus/issues/8499)
- - ArC (Quarkus' CDI implementation) has special handling for `CompletionStage[T]`, maybe we should add similar handling for `Future[T]` and `Promise[T]`, see [ActiveRequestContextInterceptor](https://github.com/quarkusio/quarkus/blob/24d3e5262d20fdaa8c056d59f012f8c7b5b1c5c8/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ActivateRequestContextInterceptor.java) ?
+ - correctly generate OpenAPI Spec for methods returning Future[T] or Promise[T], e.g. similar to [Quarkus #8499](https://github.com/quarkusio/quarkus/issues/8499)
+ - ArC (Quarkus' CDI implementation) has special handling for CompletionStage[T], maybe we should add similar handling for Future[T] and Promise[T], see [ActiveRequestContextInterceptor](https://github.com/quarkusio/quarkus/blob/24d3e5262d20fdaa8c056d59f012f8c7b5b1c5c8/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ActivateRequestContextInterceptor.java) ?

--- a/README.md
+++ b/README.md
@@ -497,7 +497,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/GavinRay97"><img src="https://avatars.githubusercontent.com/u/26604994?v=4?s=100" width="100px;" alt="Gavin Ray"/><br /><sub><b>Gavin Ray</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkus-scala3/commits?author=GavinRay97" title="Code">💻</a> <a href="#maintenance-GavinRay97" title="Maintenance">🚧</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://lesincroyableslivres.fr/"><img src="https://avatars.githubusercontent.com/u/1279749?v=4?s=100" width="100px;" alt="Guillaume Smet"/><br /><sub><b>Guillaume Smet</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkus-scala3/commits?author=gsmet" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/domdorn"><img src="https://avatars.githubusercontent.com/u/100349?v=4?s=100" width="100px;" alt="Dominik Dorn"/><br /><sub><b>Dominik Dorn</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkus-scala3/commits?author=domdorn" title="Code">🚀🍺💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ def mkRoutes(router: Router) =
 
 ### `Future[T]` and `Promise[T]` support in REST endpoints
 
-This extension allows you to return `Future[T]` and `Promise[T]` from your rest-endpoints.
+This extension allows you to return `Future[T]` and `Promise[T]` from your REST endpoints.
 
 ```scala
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ VERSIONS = [
 
 dependencies {
     implementation "io.quarkiverse.scala:quarkus-scala3:${VERSIONS.QUARKUS_SCALA3}"
+    implementation "io.quarkiverse.scala:quarkus-scala3-deployment:${VERSIONS.QUARKUS_SCALA3}"
     implementation("org.scala-lang:scala3-compiler_3") {
         version {
             strictly VERSIONS.SCALA3
@@ -133,7 +134,12 @@ In your `pom.xml` file, add:
 <dependency>
     <groupId>io.quarkiverse.scala</groupId>
     <artifactId>quarkus-scala3</artifactId>
-    <version>0.0.1<version>
+    <version>1.0.0<version>
+</dependency>
+<dependency>
+  <groupId>io.quarkiverse.scala</groupId>
+  <artifactId>quarkus-scala3-deployment</artifactId>
+  <version>1.0.0</version>
 </dependency>
 ```
 
@@ -440,6 +446,54 @@ def mkRoutes(router: Router) =
     })
 ```
 
+
+### `Future[T]` and `Promise[T]` support in Rest-Endpoints
+
+This extension allows you to return `Future[T]` and `Promise[T]` from your rest-endpoints.
+
+```scala
+
+@Path("/")
+class GreetingResource
+
+    @GET
+    @Path("/greet/future")
+    @Produces(Array(TEXT_PLAIN))
+    def futureGreeting(): Future[String] =
+       Future.successful("Hello from the future")
+    end futureGreeting
+
+    @GET
+    @Path("/greet/promise")
+    def promiseGreeting(): Promise[String] =
+      Promise.successful("Hello from the promise")
+    end promiseGreeting
+
+end GreetingResource
+```    
+
+If the `Future[T]` or `Promise[T]` fails, the normal exception handling is invoked.
+
+Make sure to have the following dependencies in your `pom.xml` to make it work:
+
+```xml
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.scala</groupId>
+      <artifactId>quarkus-scala3</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.scala</groupId>
+      <artifactId>quarkus-scala3-deployment</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+```
+
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -452,6 +506,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/GavinRay97"><img src="https://avatars.githubusercontent.com/u/26604994?v=4?s=100" width="100px;" alt="Gavin Ray"/><br /><sub><b>Gavin Ray</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkus-scala3/commits?author=GavinRay97" title="Code">💻</a> <a href="#maintenance-GavinRay97" title="Maintenance">🚧</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://lesincroyableslivres.fr/"><img src="https://avatars.githubusercontent.com/u/1279749?v=4?s=100" width="100px;" alt="Guillaume Smet"/><br /><sub><b>Guillaume Smet</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkus-scala3/commits?author=gsmet" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/domdorn"><img src="https://avatars.githubusercontent.com/u/100349?v=4?s=100" width="100px;" alt="Dominik Dorn"/><br /><sub><b>Dominik Dorn</b></sub></a><br /><a href="https://github.com/quarkiverse/quarkus-scala3/commits?author=domdorn" title="Code">🚀🍺💻</a></td>
     </tr>
   </tbody>
 </table>
@@ -462,3 +517,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
+## TODOs
+ - correctly generate OpenAPI Spec for methods returning `Future[T]` or `Promise[T]`, e.g. similar to [Quarkus #8499](https://github.com/quarkusio/quarkus/issues/8499)
+ - Quarkus-Arc has special handling for `CompletionStage[T]`, maybe we should add similar handling for `Future[T]` and `Promise[T]`, see [ActiveRequestContextInterceptor](https://github.com/quarkusio/quarkus/blob/24d3e5262d20fdaa8c056d59f012f8c7b5b1c5c8/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ActivateRequestContextInterceptor.java) ?

--- a/README.md
+++ b/README.md
@@ -520,4 +520,4 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 ## TODOs
  - correctly generate OpenAPI Spec for methods returning `Future[T]` or `Promise[T]`, e.g. similar to [Quarkus #8499](https://github.com/quarkusio/quarkus/issues/8499)
- - Quarkus-Arc has special handling for `CompletionStage[T]`, maybe we should add similar handling for `Future[T]` and `Promise[T]`, see [ActiveRequestContextInterceptor](https://github.com/quarkusio/quarkus/blob/24d3e5262d20fdaa8c056d59f012f8c7b5b1c5c8/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ActivateRequestContextInterceptor.java) ?
+ - ArC (Quarkus' CDI implementation) has special handling for `CompletionStage[T]`, maybe we should add similar handling for `Future[T]` and `Promise[T]`, see [ActiveRequestContextInterceptor](https://github.com/quarkusio/quarkus/blob/24d3e5262d20fdaa8c056d59f012f8c7b5b1c5c8/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ActivateRequestContextInterceptor.java) ?

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ def mkRoutes(router: Router) =
 ```
 
 
-### `Future[T]` and `Promise[T]` support in Rest-Endpoints
+### `Future[T]` and `Promise[T]` support in REST endpoints
 
 This extension allows you to return `Future[T]` and `Promise[T]` from your rest-endpoints.
 

--- a/futures/deployment/pom.xml
+++ b/futures/deployment/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.scala</groupId>
+        <artifactId>quarkus-scala3-futures-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-scala3-futures-deployment</artifactId>
+    <name>Quarkus Scala3 futures - Deployment</name>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.scala</groupId>
+            <artifactId>quarkus-scala3-futures</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-spi-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.resteasy.reactive</groupId>
+            <artifactId>resteasy-reactive-processor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-server-spi-deployment</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala3-library_3</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/futures/deployment/pom.xml
+++ b/futures/deployment/pom.xml
@@ -17,7 +17,7 @@
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkiverse.scala</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>quarkus-scala3-futures</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -40,11 +40,6 @@
             <artifactId>quarkus-rest-server-spi-deployment</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala3-library_3</artifactId>
-            <scope>compile</scope>
-        </dependency>
 
     </dependencies>
 

--- a/futures/deployment/src/main/scala/io/quarkiverse/scala/scala3/futures/deployment/Scala3FutureResponseHandler.java
+++ b/futures/deployment/src/main/scala/io/quarkiverse/scala/scala3/futures/deployment/Scala3FutureResponseHandler.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.scala.scala3.deployment;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+
+public class Scala3FutureResponseHandler implements ServerRestHandler {
+
+    private void handleFuture(ResteasyReactiveRequestContext requestContext,
+            scala.concurrent.Future<?> f) {
+
+        requestContext.suspend();
+
+        f.onComplete(tryValue -> {
+            if (tryValue.isSuccess()) {
+                requestContext.setResult(tryValue.get());
+            } else {
+                requestContext.handleException(tryValue.failed().get(), true);
+            }
+            requestContext.resume();
+            return null;
+        }, scala.concurrent.ExecutionContext.global());
+
+    }
+
+    @Override
+    public void handle(ResteasyReactiveRequestContext requestContext) throws Exception {
+        if (requestContext.getResult() instanceof scala.concurrent.Future<?> future) {
+            handleFuture(requestContext, future);
+        } else if (requestContext.getResult() instanceof scala.concurrent.Promise<?> promise) {
+            handleFuture(requestContext, promise.future());
+        }
+    }
+
+}

--- a/futures/deployment/src/main/scala/io/quarkiverse/scala/scala3/futures/deployment/Scala3FutureReturnTypeMethodScanner.java
+++ b/futures/deployment/src/main/scala/io/quarkiverse/scala/scala3/futures/deployment/Scala3FutureReturnTypeMethodScanner.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.scala.scala3.deployment;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.resteasy.reactive.server.model.FixedHandlerChainCustomizer;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer.Phase;
+import org.jboss.resteasy.reactive.server.processor.scanning.MethodScanner;
+
+public class Scala3FutureReturnTypeMethodScanner implements MethodScanner {
+    private static final DotName FUTURE = DotName.createSimple("scala.concurrent.Future");
+    private static final DotName PROMISE = DotName.createSimple("scala.concurrent.Promise");
+    private static final DotName BLOCKING_ANNOTATION = DotName.createSimple("io.smallrye.common.annotation.Blocking");
+
+    private void ensureNotBlocking(MethodInfo method) {
+        if (method.annotation(BLOCKING_ANNOTATION) != null) {
+            String format = String.format("Suspendable @Blocking methods are not supported yet: %s.%s",
+                    method.declaringClass().name(), method.name());
+            throw new IllegalStateException(format);
+        }
+    }
+
+    public Scala3FutureReturnTypeMethodScanner() {
+    }
+
+    @Override
+    public List<HandlerChainCustomizer> scan(MethodInfo method, ClassInfo actualEndpointClass,
+            Map<String, Object> methodContext) {
+
+        if (isMethodSignatureAsync(method)) {
+            ensureNotBlocking(method);
+
+            return Collections.singletonList(new FixedHandlerChainCustomizer(
+                    new Scala3FutureResponseHandler(), Phase.AFTER_METHOD_INVOKE));
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isMethodSignatureAsync(MethodInfo info) {
+        DotName name = info.returnType().name();
+        return name.equals(FUTURE) || name.equals(PROMISE);
+    }
+
+}

--- a/futures/deployment/src/main/scala/io/quarkiverse/scala/scala3/futures/deployment/Scala3FuturesJavaProcessor.java
+++ b/futures/deployment/src/main/scala/io/quarkiverse/scala/scala3/futures/deployment/Scala3FuturesJavaProcessor.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.scala.scala3.futures.deployment;
 
-import io.quarkiverse.scala.scala3.deployment.Scala3FutureReturnTypeMethodScanner;
+import io.quarkiverse.scala.scala3.futures.runtime.Scala3FutureReturnTypeMethodScanner;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.MethodScannerBuildItem;

--- a/futures/deployment/src/main/scala/io/quarkiverse/scala/scala3/futures/deployment/Scala3FuturesJavaProcessor.java
+++ b/futures/deployment/src/main/scala/io/quarkiverse/scala/scala3/futures/deployment/Scala3FuturesJavaProcessor.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.scala.scala3.futures.deployment;
+
+import io.quarkiverse.scala.scala3.deployment.Scala3FutureReturnTypeMethodScanner;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.resteasy.reactive.server.spi.MethodScannerBuildItem;
+
+public class Scala3FuturesJavaProcessor {
+
+    @BuildStep
+    public FeatureBuildItem feature() {
+        return new FeatureBuildItem("scala3-futures");
+    }
+
+    @BuildStep
+    public MethodScannerBuildItem registerFuturesRestReturnTypes() {
+        return new MethodScannerBuildItem(new Scala3FutureReturnTypeMethodScanner());
+    }
+}

--- a/futures/deployment/src/test/scala/io/quarkiverse/scala/scala3/futures/test/Scala3FuturesDevModeTest.scala
+++ b/futures/deployment/src/test/scala/io/quarkiverse/scala/scala3/futures/test/Scala3FuturesDevModeTest.scala
@@ -1,0 +1,23 @@
+package io.quarkiverse.scala.scala3.futures.test
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+class Scala3FuturesDevModeTest {
+
+    // Start hot reload (DevMode) test with your extension loaded
+    @RegisterExtension
+    val devModeTest: QuarkusDevModeTest = new QuarkusDevModeTest()
+            .setArchiveProducer(() => ShrinkWrap.create(classOf[JavaArchive]))
+
+    @Test
+    def writeYourOwnDevModeTest(): Unit = {
+        // Write your dev mode tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-hot-reload for more information
+        Assertions.assertTrue(true, "Add dev mode assertions to " + getClass().getName());
+    }
+}

--- a/futures/deployment/src/test/scala/io/quarkiverse/scala/scala3/futures/test/Scala3FuturesTest.scala
+++ b/futures/deployment/src/test/scala/io/quarkiverse/scala/scala3/futures/test/Scala3FuturesTest.scala
@@ -1,0 +1,23 @@
+package io.quarkiverse.scala.scala3.futures.test
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class Scala3FuturesTest {
+
+    // Start unit test with your extension loaded
+    @RegisterExtension
+    def unitTest: QuarkusUnitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() => ShrinkWrap.create(classOf[JavaArchive]))
+
+    @Test
+    def writeYourOwnUnitTest(): Unit = {
+        // Write your unit tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-extensions for more information
+        Assertions.assertTrue(true, "Add some assertions to " + getClass().getName());
+    }
+}

--- a/futures/integration-tests/pom.xml
+++ b/futures/integration-tests/pom.xml
@@ -24,11 +24,11 @@
             <artifactId>quarkus-scala3-futures</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.scala</groupId>
-            <artifactId>quarkus-scala3-futures-deployment</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>io.quarkiverse.scala</groupId>-->
+<!--            <artifactId>quarkus-scala3-futures-deployment</artifactId>-->
+<!--            <version>${project.version}</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-compiler_3</artifactId>

--- a/futures/integration-tests/pom.xml
+++ b/futures/integration-tests/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.scala</groupId>
+        <artifactId>quarkus-scala3-futures-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-scala3-futures-integration-tests</artifactId>
+    <name>Quarkus Scala3 futures - Integration Tests</name>
+
+    <properties>
+        <skipITs>false</skipITs>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.scala</groupId>
+            <artifactId>quarkus-scala3-futures</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.scala</groupId>
+            <artifactId>quarkus-scala3-futures-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala3-compiler_3</artifactId>
+            <version>${scala.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala3-library_3</artifactId>
+            <version>${scala.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <skipITs>false</skipITs>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/futures/integration-tests/src/main/scala/io/quarkiverse/scala/scala3/futures/it/Scala3FuturesResource.scala
+++ b/futures/integration-tests/src/main/scala/io/quarkiverse/scala/scala3/futures/it/Scala3FuturesResource.scala
@@ -1,0 +1,38 @@
+package io.quarkiverse.scala.scala3.futures.it
+
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType.TEXT_PLAIN
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.ExecutionContext.Implicits.global
+
+@Path("")
+class Scala3FuturesResource {
+
+  @GET
+  @Path("/hello")
+  def hello(): String = "Hello from Scala 3.4.1"
+
+  @GET
+  @Path("/simple-future")
+  @Produces(Array(TEXT_PLAIN))
+  def simpleFuture: Future[String] = for {
+    _ <- Future { Thread.sleep(2000L) }
+    s <- Future.successful("Hello from a Future in Scala 3.4.1")
+  } yield s
+
+  @GET
+  @Path("simple-promise")
+  @Produces(Array(TEXT_PLAIN))
+  def simplePromise: Promise[String] = Promise.successful("Promise returned")
+  
+  
+  @GET
+  @Path("future-failure")
+  @Produces(Array(TEXT_PLAIN))
+  def futureFailure: Future[String] = Future.failed(new RuntimeException("Future failed"))
+
+}

--- a/futures/integration-tests/src/test/scala/io/quarkiverse/scala/scala3/futures/it/Given.scala
+++ b/futures/integration-tests/src/test/scala/io/quarkiverse/scala/scala3/futures/it/Given.scala
@@ -1,0 +1,26 @@
+package io.quarkiverse.scala.scala3.futures.it
+
+import io.restassured.RestAssured.*
+import io.restassured.internal.{ResponseSpecificationImpl, ValidatableResponseImpl}
+import io.restassured.response.{ExtractableResponse, Response, ValidatableResponse}
+import io.restassured.specification.{RequestSender, RequestSpecification, ResponseSpecification}
+
+class GivenConstructor(givenBlock: RequestSpecification => RequestSpecification):
+  def When(whenBlock: RequestSpecification => Response): ExpectationConstructor =
+    ExpectationConstructor(givenBlock, whenBlock)
+
+  class ExpectationConstructor(
+                                givenBlock: RequestSpecification => RequestSpecification,
+                                whenBlock: RequestSpecification => Response
+                              ):
+    def Then(validatable: ValidatableResponse => Unit) =
+      val appliedGiven: RequestSpecification = givenBlock.apply(`given`())
+      val appliedWhen: Response              = whenBlock.apply(appliedGiven)
+      validatable.apply(appliedWhen.`then`())
+
+object Given:
+  def apply(givenBlock: RequestSpecification => RequestSpecification): GivenConstructor = GivenConstructor(givenBlock)
+
+def When(whenBlock: RequestSpecification => Response) =
+  def blankGiven(givenBlock: RequestSpecification): RequestSpecification = `given`()
+  Given(blankGiven).When(whenBlock)

--- a/futures/integration-tests/src/test/scala/io/quarkiverse/scala/scala3/futures/it/NativeScala3FuturesResourceIT.scala
+++ b/futures/integration-tests/src/test/scala/io/quarkiverse/scala/scala3/futures/it/NativeScala3FuturesResourceIT.scala
@@ -1,0 +1,8 @@
+package io.quarkiverse.scala.scala3.futures.it
+
+import io.quarkus.test.junit.QuarkusIntegrationTest
+
+@QuarkusIntegrationTest
+class NativeScala3FuturesResourceIT extends Scala3FuturesResourceTest {
+
+}

--- a/futures/integration-tests/src/test/scala/io/quarkiverse/scala/scala3/futures/it/Scala3FuturesResourceTest.scala
+++ b/futures/integration-tests/src/test/scala/io/quarkiverse/scala/scala3/futures/it/Scala3FuturesResourceTest.scala
@@ -1,0 +1,58 @@
+package io.quarkiverse.scala.scala3.futures.it
+
+import org.hamcrest.Matchers.is
+import org.junit.jupiter.api.Test
+import io.quarkus.test.junit.QuarkusTest
+import org.hamcrest.Matchers
+
+@QuarkusTest
+class Scala3FuturesResourceTest {
+
+
+
+  @Test
+  def `test Hello Endpoint`(): Unit = {
+    Given {
+      _.params("something", "value")
+    }.When {
+      _.get("/hello").prettyPeek()
+    }.Then {
+      _.statusCode(200).body(is("Hello from Scala 3.4.1"))
+    }
+  }
+
+  @Test
+  def `test future Endpoint`(): Unit = {
+    Given {
+      _.params("something", "value")
+    }.When {
+      _.get("/simple-future").prettyPeek()
+    }.Then {
+      _.statusCode(200).body(is("Hello from a Future in Scala 3.4.1"))
+    }
+  }
+
+  @Test
+  def `test promise Endpoint`(): Unit = {
+    Given {
+      _.params("something", "value")
+    }.When {
+      _.get("/simple-promise").prettyPeek()
+    }.Then {
+      _.statusCode(200).body(is("Promise returned"))
+    }
+  }
+
+  @Test
+  def `future should fail`(): Unit = {
+    Given {
+      _.params("something", "value")
+    }.When {
+      _.get("/future-failure").prettyPeek()
+    }.Then {
+      _.statusCode(500).body(Matchers.containsString("Future failed"))
+    }
+  }
+
+
+}

--- a/futures/integration-tests/src/test/scala/io/quarkiverse/scala/scala3/futures/it/Scala3FuturesResourceTest.scala
+++ b/futures/integration-tests/src/test/scala/io/quarkiverse/scala/scala3/futures/it/Scala3FuturesResourceTest.scala
@@ -15,7 +15,7 @@ class Scala3FuturesResourceTest {
     Given {
       _.params("something", "value")
     }.When {
-      _.get("/hello").prettyPeek()
+      _.get("/hello")
     }.Then {
       _.statusCode(200).body(is("Hello from Scala 3.4.1"))
     }
@@ -26,7 +26,7 @@ class Scala3FuturesResourceTest {
     Given {
       _.params("something", "value")
     }.When {
-      _.get("/simple-future").prettyPeek()
+      _.get("/simple-future")
     }.Then {
       _.statusCode(200).body(is("Hello from a Future in Scala 3.4.1"))
     }
@@ -37,7 +37,7 @@ class Scala3FuturesResourceTest {
     Given {
       _.params("something", "value")
     }.When {
-      _.get("/simple-promise").prettyPeek()
+      _.get("/simple-promise")
     }.Then {
       _.statusCode(200).body(is("Promise returned"))
     }
@@ -50,7 +50,9 @@ class Scala3FuturesResourceTest {
     }.When {
       _.get("/future-failure").prettyPeek()
     }.Then {
-      _.statusCode(500).body(Matchers.containsString("Future failed"))
+      _.statusCode(500)
+      // body/stack not available in native image?
+      //.body(Matchers.containsString("Future failed"))
     }
   }
 

--- a/futures/pom.xml
+++ b/futures/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.scala</groupId>
+        <artifactId>quarkus-scala3-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-scala3-futures-parent</artifactId>
+    <version>999-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Quarkus Scala3 futures - Parent</name>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+    <properties>
+        <compiler-plugin.version>3.12.1</compiler-plugin.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <quarkus.version>3.10.0</quarkus.version>
+        <scala-maven-plugin.version>4.9.1</scala-maven-plugin.version>
+        <scala.version>3.3.3</scala.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala3-library_3</artifactId>
+                <version>${scala.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>${quarkus.version}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>net.alchim31.maven</groupId>
+                    <artifactId>scala-maven-plugin</artifactId>
+                    <version>${scala-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <?m2e ignore?>
+                            <id>scala-compile-first</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                                <goal>compile</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <?m2e ignore?>
+                            <id>scala-test-compile</id>
+                            <phase>process-test-resources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                                <goal>testCompile</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <args>
+                            <arg>-Wunused:all</arg>
+                            <arg>-feature</arg>
+                            <arg>-deprecation</arg>
+                            <arg>-Ysemanticdb</arg>
+                        </args>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>it</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <modules>
+                <module>integration-tests</module>
+            </modules>
+        </profile>
+    </profiles>
+</project>

--- a/futures/runtime/pom.xml
+++ b/futures/runtime/pom.xml
@@ -15,9 +15,24 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus.resteasy.reactive</groupId>
+            <artifactId>resteasy-reactive-processor</artifactId>
+        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>io.quarkus</groupId>-->
+<!--            <artifactId>quarkus-rest-server-spi-deployment</artifactId>-->
+<!--        </dependency>-->
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala3-library_3</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>
@@ -46,6 +61,10 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/futures/runtime/pom.xml
+++ b/futures/runtime/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.scala</groupId>
+        <artifactId>quarkus-scala3-futures-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-scala3-futures</artifactId>
+    <name>Quarkus Scala3 futures - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:quarkus-scala3-futures-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/futures/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/futures/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+name: Scala 3 Futures Support
+description: Support for using `Future[T]` and `Promise[T]` in REST Endpoints.
+metadata:
+  keywords:
+    - scala
+    - scala3
+    - futures
+  guide: https://docs.quarkiverse.io/quarkus-scala3/dev/index.html
+  categories:
+    - "alt-languages"
+  status: "preview"

--- a/futures/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/futures/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,5 @@
 name: Scala 3 Futures Support
-description: Support for using `Future[T]` and `Promise[T]` in REST Endpoints.
+description: Support for using Future[T] and Promise[T] in REST Endpoints.
 metadata:
   keywords:
     - scala

--- a/futures/runtime/src/main/scala/io/quarkiverse/scala/scala3/futures/runtime/Scala3FutureResponseHandler.java
+++ b/futures/runtime/src/main/scala/io/quarkiverse/scala/scala3/futures/runtime/Scala3FutureResponseHandler.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.scala.scala3.deployment;
+package io.quarkiverse.scala.scala3.futures.runtime;
 
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;

--- a/futures/runtime/src/main/scala/io/quarkiverse/scala/scala3/futures/runtime/Scala3FutureReturnTypeMethodScanner.java
+++ b/futures/runtime/src/main/scala/io/quarkiverse/scala/scala3/futures/runtime/Scala3FutureReturnTypeMethodScanner.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.scala.scala3.deployment;
+package io.quarkiverse.scala.scala3.futures.runtime;
 
 import java.util.Collections;
 import java.util.List;

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse</groupId>
     <artifactId>quarkiverse-parent</artifactId>
-    <version>15</version>
+    <version>16</version>
   </parent>
   <groupId>io.quarkiverse.scala</groupId>
   <artifactId>quarkus-scala3-parent</artifactId>
@@ -14,6 +14,7 @@
   <modules>
     <module>deployment</module>
     <module>runtime</module>
+    <module>futures</module>
   </modules>
   <scm>
     <connection>:git:git@github.com:quarkiverse/quarkus-scala3.git</connection>
@@ -24,7 +25,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.6.4</quarkus.version>
+    <quarkus.version>3.10.0</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This PR adds support for `Future[T]` and `Promise[T]` as return types in resources, e.g. 
```scala

@Path("/")
class GreetingResource() 
    @GET
    @Path("/greet/promise")
    def promiseGreeting(): Promise[String] =
      Promise.successful("Hello from the promise")
    end promiseGreeting
end GreetingResource
```

I also added tests in the integration module and converted them to be in Scala